### PR TITLE
Update to 2.2.4

### DIFF
--- a/org.mixxx.Mixxx.yaml
+++ b/org.mixxx.Mixxx.yaml
@@ -13,7 +13,8 @@ finish-args:
   - --persist=.mixxx
   - --device=all
   - --metadata=X-DConf=migrate-path=/org/mixxx/Mixxx
-  - --env=LADSPA_PATH=${FLATPAK_DEST}/lib/ladspa
+  - --env=QT_QPA_PLATFORM=xcb
+  - --env=LADSPA_PATH=/app/lib/ladspa
   - --system-talk-name=org.freedesktop.UPower
   - --env=ALSA_CONFIG_PATH=
 rename-desktop-file: mixxx.desktop

--- a/org.mixxx.Mixxx.yaml
+++ b/org.mixxx.Mixxx.yaml
@@ -290,7 +290,7 @@ modules:
       - desktop-file-edit --set-key="Icon" --set-value=${FLATPAK_ID} ${FLATPAK_DEST}/share/applications/mixxx.desktop
     sources:
       - type: archive
-        url: https://github.com/mixxxdj/mixxx/archive/release-2.2.3.tar.gz
-        sha256: 69230dca511ba08a284a22a979ff05b62130e97156d39a044bb4045f5f43cd2e
+        url: https://github.com/mixxxdj/mixxx/archive/release-2.2.4.tar.gz
+        sha256: 9372b43d5ec882845b4fe2350ef50dabb3f1e0cc029f182b0ed8aa4f4f3b2afa
       - type: patch
         path: patches/mixxx/appdata.patch

--- a/patches/mixxx/appdata.patch
+++ b/patches/mixxx/appdata.patch
@@ -2,12 +2,38 @@ diff --git a/res/linux/mixxx.appdata.xml b/res/linux/mixxx.appdata.xml
 index 39bb082aeb..31a24f8289 100644
 --- a/res/linux/mixxx.appdata.xml
 +++ b/res/linux/mixxx.appdata.xml
-@@ -48,4 +48,33 @@
+@@ -48,4 +48,59 @@
    <url type="help">https://www.mixxx.org/support</url>
    <url type="translate">https://www.transifex.com/mixxx-dj-software/public</url>
    <update_contact>mixxx-devel@lists.sourceforge.net</update_contact>
 +  <content_rating type="oars-1.0" />
 +  <releases>
++    <release version="2.2.4" date="2020-05-10">
++      <url>https://github.com/mixxxdj/mixxx/releases/tag/release-2.2.4</url>
++      <description>
++        <ul>
++          <li>Store default recording format after "Restore Defaults" lp:1857806 #2414</li>
++          <li>Prevent infinite loop when decoding corrupt MP3 files #2417</li>
++          <li>Add workaround for broken libshout versions #2040 #2438</li>
++          <li>Speed up purging of tracks lp:1845837 #2393</li>
++          <li>Don't stop playback if vinyl passthrough input is configured and PASS button is pressed #2474</li>
++          <li>Fix debug assertion for invalid crate names lp:1861431 #2477</li>
++          <li>Fix crashes when executing actions on tracks that already disappeared from the DB #2527</li>
++          <li>AutoDJ: Skip next track when both deck are playing lp:1399974 #2531</li>
++          <li>Tweak scratch parameters for Mixtrack Platinum #2028</li>
++          <li>Fix auto tempo going to infinity on Pioneer DDJ-SB2 #2559</li>
++          <li>Fix bpm.tapButton logic and reject missed &amp; double taps #2594</li>
++          <li>Add controller mapping for Native Instruments Traktor Kontrol S2 MK3 #2348</li>
++          <li>Add controller mapping for Soundless joyMIDI #2425</li>
++          <li>Add controller mapping for Hercules DJControl Inpulse 300 #2465</li>
++          <li>Add controller mapping for Denon MC7000 #2546</li>
++          <li>Add controller mapping for Stanton DJC.4 #2607</li>
++          <li>Fix broadcasting via broadcast/recording input lp:1876222 #2743</li>
++          <li>Only apply ducking gain in manual ducking mode when talkover is enabed lp:1394968 lp:1737113 lp:1662536 #2759</li>
++          <li>Ignore MIDI Clock Messages (0xF8) because they are not usable in Mixxx and inhibited the screensaver #2786</li>
++        </ul>
++      </description>
++    </release>
 +    <release version="2.2.3" date="2019-12-09">
 +      <url>https://github.com/mixxxdj/mixxx/releases/tag/release-2.2.3</url>
 +      <description>


### PR DESCRIPTION
Update to 2.2.4

Minor fixes to the manifest:
- force the xcb backend of Qt. This solve the issues I see of menu position on screen and translucent area (ie the window has a hole and I see my terminal underneath)
- FLATPAK_DEST doesn't exist at runtime, so LADSPA_PATH is properly set. Albeit I saw no change with that.