### PR TITLE
Remove LADSPA and use unified extension point

### DIFF
--- a/org.mixxx.Mixxx.yaml
+++ b/org.mixxx.Mixxx.yaml
@@ -14,13 +14,19 @@ finish-args:
   - --device=all
   - --metadata=X-DConf=migrate-path=/org/mixxx/Mixxx
   - --env=QT_QPA_PLATFORM=xcb
-  - --env=LADSPA_PATH=/app/extensions/LadspaPlugins/ladspa:/app/lib/ladspa
-  - --env=LV2_PATH=/app/extensions/Lv2Plugins/lv2
+  - --env=LV2_PATH=/app/extensions/Plugins/lv2:/app/extensions/Lv2Plugins/lv2
   - --system-talk-name=org.freedesktop.UPower
   - --env=ALSA_CONFIG_PATH=
 rename-desktop-file: mixxx.desktop
 rename-appdata-file: mixxx.appdata.xml
 add-extensions:
+  org.freedesktop.LinuxAudio.Plugins:
+     directory: extensions/Plugins
+     version: '19.08'
+     add-ld-path: lib
+     merge-dirs: ladspa;lv2
+     subdirectories: true
+     no-autodownload: true
   org.freedesktop.LinuxAudio.Lv2Plugins:
      directory: extensions/Lv2Plugins
      version: '19.08'
@@ -28,13 +34,6 @@ add-extensions:
      merge-dirs: lv2
      subdirectories: true
      no-autodownload: true
-  org.freedesktop.LinuxAudio.LadspaPlugins:
-    directory: extensions/LadspaPlugins
-    version: '19.08'
-    add-ld-path: lib
-    merge-dirs: ladspa
-    subdirectories: true
-    no-autodownload: true
 cleanup:
   - /include
   - /share/man
@@ -304,7 +303,7 @@ modules:
     post-install:
       - desktop-file-edit --set-key="Exec" --set-value="mixxx %U" ${FLATPAK_DEST}/share/applications/mixxx.desktop
       - desktop-file-edit --set-key="Icon" --set-value=${FLATPAK_ID} ${FLATPAK_DEST}/share/applications/mixxx.desktop
-      - install -d /app/extensions/LadspaPlugins
+      - install -d /app/extensions/Plugins
       - install -d /app/extensions/Lv2Plugins
     sources:
       - type: archive


### PR DESCRIPTION
- I added the new extension point that unify all format. The older Lv2 is kept until everything is migrated.
- I removed LADSPA plugins because there is no support of LADSPA in Mixxx. It was removed in 2014

On a side note I don't think building the ladspa SDK is need for rubberband, I can do a followup later if you want.