### PR TITLE
Upgrade protobuf from 3.17.3 (all) to 3.18.0 (cpp) 

### DIFF
--- a/org.mixxx.Mixxx.yaml
+++ b/org.mixxx.Mixxx.yaml
@@ -122,7 +122,7 @@ modules:
         sha256: ce60a545acf0f30cb96b5f298b74bb65caa513a56299e0435fc8f09dadc5e6ed
 
   - name: upower
-    config-opts: 
+    config-opts:
       - --disable-static
       - --with-pic
       - --with-systemdsystemunitdir=/app/lib/systemd/system
@@ -139,7 +139,7 @@ modules:
       - type: git
         url: https://gitlab.freedesktop.org/wtaymans/fdk-aac-stripped.git
         commit: 585981a49f2186b0d2e47c64bf6b5abf539395f8
-  
+
   - name: libmodplug
     config-opts:
       - --with-pic

--- a/org.mixxx.Mixxx.yaml
+++ b/org.mixxx.Mixxx.yaml
@@ -56,8 +56,8 @@ modules:
       - --with-pic
     sources:
       - type: archive
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v3.17.3/protobuf-all-3.17.3.tar.gz
-        sha256: 77ad26d3f65222fd96ccc18b055632b0bfedf295cb748b712a98ba1ac0b704b2
+        url: https://github.com/protocolbuffers/protobuf/releases/download/v3.18.0/protobuf-cpp-3.18.0.tar.gz
+        sha256: 7308590dbb95e77066b99c5674eed855c8257e70658d2af586f4a81ff0eea2b1
     cleanup:
       - /bin
 


### PR DESCRIPTION
The *cpp* package is sufficient, we don't need to download *all*.