### PR TITLE
Update to Mixxx 2.5.0 with Qt 6 based KDE runtime

### DIFF
--- a/org.mixxx.Mixxx.metainfo.xml
+++ b/org.mixxx.Mixxx.metainfo.xml
@@ -42,23 +42,48 @@
   <url type="vcs-browser">https://github.com/mixxxdj/mixxx</url>
   <screenshots>
     <screenshot type="default">
-      <image>https://mixxx.org/theme/images/2.4/screenshots/Latenight_2decks_basic.png</image>
+      <image>https://mixxx.org/theme/images/2.5/screenshots/Latenight_2decks_basic.png</image>
       <caption>Mixxx with LateNight PaleMoon skin and two decks</caption>
     </screenshot>
     <screenshot>
-      <image>https://mixxx.org/theme/images/2.4/screenshots/Deere_2decks_basic.png</image>
+      <image>https://mixxx.org/theme/images/2.5/screenshots/Deere_2decks_basic.png</image>
       <caption>Mixxx with Deere skin and two decks</caption>
     </screenshot>
     <screenshot>
-      <image>https://mixxx.org/theme/images/2.4/screenshots/Tango_2decks_basic.png</image>
+      <image>https://mixxx.org/theme/images/2.5/screenshots/Tango_2decks_basic.png</image>
       <caption>Mixxx with Tango skin and two decks</caption>
     </screenshot>
     <screenshot>
-      <image>https://mixxx.org/theme/images/2.4/screenshots/Shade_basic.png</image>
+      <image>https://mixxx.org/theme/images/2.5/screenshots/Shade_basic.png</image>
       <caption>Mixxx with Shade skin</caption>
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.5.0" date="2024-12-24">
+    <url type="details">https://github.com/mixxxdj/mixxx/blob/2.5/CHANGELOG.md</url>
+      <description>
+        <p>
+          Mixxx 2.5.0 is a major release with tons of new features and important
+          changes under the hood. It includes the following highlights:
+        </p>
+        <ul>
+          <li>Mixxx now uses the latest Qt 6 framework, offering improved
+          performance and enhanced compatibility with modern systems</li>
+          <li>Adjustable beatloop anchor and BPM rate tap &amp; change undo features</li>
+          <li>New audio effects: compressor and glitch</li>
+          <li>Support for storing and restoring regular loops when toggling rolling loops</li>
+          <li>Keyboard shortcuts for playlist management and custom track colors for
+          played and missing tracks</li>
+          <li>Sidebar actions for playlist shuffle and directory tree refresh</li>
+          <li>New multi-track property / batch tag editor and enhanced search filters</li>
+          <li>Support for starting auto DJ on launch and automatically hiding the menubar</li>
+          <li>Split RGB GLSL waveforms for visualizing slip mode position and waveform
+          beats / time display until next marker</li>
+          <li>Improved mappings for Denon MC7000, Numark Scratch, Pioneer DDJ-FLX4,
+          NI Traktor Kontrol S4 MK3 and MIDI for light</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.4.2" date="2024-11-26">
     <url type="details">https://github.com/mixxxdj/mixxx/blob/2.4.2/CHANGELOG.md</url>
       <description>

--- a/org.mixxx.Mixxx.yaml
+++ b/org.mixxx.Mixxx.yaml
@@ -1,6 +1,6 @@
 app-id: org.mixxx.Mixxx
 runtime: org.kde.Platform
-runtime-version: '5.15-24.08'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: mixxx
 rename-icon: mixxx
@@ -139,8 +139,8 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: archive
-        url: https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protobuf-28.3.tar.gz
-        sha256: 7c3ebd7aaedd86fa5dc479a0fda803f602caaf78d8aff7ce83b89e1b8ae7442a
+        url: https://github.com/protocolbuffers/protobuf/releases/download/v29.2/protobuf-29.2.tar.gz
+        sha256: 63150aba23f7a90fd7d87bdf514e459dd5fe7023fdde01b56ac53335df64d4bd
     cleanup:
       - /bin
 
@@ -285,6 +285,8 @@ modules:
   - name: qtkeychain
     buildsystem: cmake-ninja
     config-opts:
+      # Build with Qt 6 support
+      - -DBUILD_WITH_QT6=ON
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: archive
@@ -325,7 +327,7 @@ modules:
         url: https://github.com/xsco/libdjinterop/archive/refs/tags/0.22.1.tar.gz
         sha256: e811158d42c3864f5b682bcf76e0af78278050439d82d14d592dd0a391da6b20
 
-  # Mixxx 2.4.2
+  # Mixxx 2.5.0
   - name: mixxx
     buildsystem: cmake-ninja
     config-opts:
@@ -340,8 +342,8 @@ modules:
       - install -d /app/extensions/Plugins
     sources:
     - type: archive
-      url: https://github.com/mixxxdj/mixxx/archive/refs/tags/2.4.2.tar.gz
-      sha256: 364a731e132e610fceb7875f508a321619ce7c5430e236a7fe77e08c4f0b3234
+      url: https://github.com/mixxxdj/mixxx/archive/refs/tags/2.5.0.tar.gz
+      sha256: 95ad113f1988abaa4fabc2e19027d5456a6ba9cb0f6366a386a2239030f41089
     - type: file
       path: org.mixxx.Mixxx.metainfo.xml
     - type: script

--- a/org.mixxx.Mixxx.yaml
+++ b/org.mixxx.Mixxx.yaml
@@ -215,8 +215,8 @@ modules:
       - -Dlv2=disabled
     sources:
       - type: archive
-        url: https://github.com/breakfastquay/rubberband/archive/refs/tags/v4.0.0.tar.gz
-        sha256: 24300f48a8014b7c863b573a9647e61b1b19b37875e2cdd92005e64c6424d266
+        url: https://github.com/breakfastquay/rubberband/archive/refs/tags/v3.3.0.tar.gz
+        sha256: 2bb837fe00932442ca90e185af8a468f7591df0c002b4a9e27a1bced1563ac84
 
   # Audio time stretching and pitch shifting library
   - name: soundtouch


### PR DESCRIPTION
This PR updates Mixxx to version 2.5.0 and switches to the latest Qt 6 based KDE runtime.

Building with Qt 6 is now default for Mixxx and the next major version will drop Qt 5 support entirely. This is a big change, so testing is very much appreciated. Personally I haven't seen any odd Flatpak related behavior, so hopefully things are good to go.

Other than that the changes are rather small - just the usual submodule, dependency, changelog and screenshot updates. Happy DJing and let me know if fixes are needed. Thanks!