### PR TITLE
Bump Mixxx to version 2.5.2

### DIFF
--- a/org.mixxx.Mixxx.metainfo.xml
+++ b/org.mixxx.Mixxx.metainfo.xml
@@ -59,6 +59,25 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.5.2" date="2025-05-14">
+    <url type="details">https://github.com/mixxxdj/mixxx/blob/2.5.2/CHANGELOG.md</url>
+      <description>
+        <p>
+          Mixxx 2.5.2 is a new minor release with several improvements and bugfixes.
+          The release highlights include:
+        </p>
+        <ul>
+          <li>New initial mapping for Arturia KeyLab Mk1</li>
+          <li>Updated mappings for Denon MC7000, DJ TechTools MIDI Fighter Twister,
+          Hercules DJControl Inpulse 500, Numark Mixtrack Platinium FX, Traktor S2 MK3,
+          and Traktor S4 MK2 &amp; MK3</li>
+          <li>Various fixes for playlist export, track sorting, drag &amp; drop and
+          keyboard mappings</li>
+          <li>Improved control picker with support for MIDI Aux/Mic controls</li>
+          <li>Loop anchor toggles for Deere, Shade and Tango skins</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.5.1" date="2025-04-27">
     <url type="details">https://github.com/mixxxdj/mixxx/blob/2.5.1/CHANGELOG.md</url>
       <description>

--- a/org.mixxx.Mixxx.yaml
+++ b/org.mixxx.Mixxx.yaml
@@ -314,7 +314,7 @@ modules:
         url: https://github.com/xsco/libdjinterop/archive/refs/tags/0.24.3.tar.gz
         sha256: df41fe39bed9d16d27a3649d237b68edd2cdb6fc71a82cae5cd746d4e4ef6578
 
-  # Mixxx 2.5.1
+  # Mixxx 2.5.2
   - name: mixxx
     buildsystem: cmake-ninja
     config-opts:
@@ -330,7 +330,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/mixxxdj/mixxx.git
-        tag: '2.5.1'
+        tag: '2.5.2'
       - type: file
         path: org.mixxx.Mixxx.metainfo.xml
       - type: script


### PR DESCRIPTION
This PR updates Mixxx to new version 2.5.2. Dependencies were updated on the recent 2.5.1 release, so only the usual manifest and metadata updates this time.

I did a quick smoke test on a local Flatpak build and everything worked as expected.