### PR TITLE
Bump Mixxx to version 2.5.3

### DIFF
--- a/org.mixxx.Mixxx.metainfo.xml
+++ b/org.mixxx.Mixxx.metainfo.xml
@@ -59,6 +59,24 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="2.5.3" date="2025-09-02">
+    <url type="details">https://github.com/mixxxdj/mixxx/blob/2.5.3/CHANGELOG.md</url>
+      <description>
+        <p>
+          Mixxx 2.5.3 is a minor release with several improvements and bugfixes.
+          The release highlights include:
+        </p>
+        <ul>
+          <li>Vastly improved Digital Vinyl System (DVS) with accurate Kalman-Filter
+          based pitch detection and quadratune phase tracker</li>
+          <li>New controller mapping for Icon P1-Nano MIDI 1</li>
+          <li>Updated mappings for Traktor Kontrol S4 Mk3, Traktor Kontrol S3,
+          Traktor Kontrol S2 and Numark NS6II</li>
+          <li>More robust waveform scratching functionality</li>
+          <li>Expanded translations for broadcast settings and track eject</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.5.2" date="2025-05-14">
     <url type="details">https://github.com/mixxxdj/mixxx/blob/2.5.2/CHANGELOG.md</url>
       <description>

--- a/org.mixxx.Mixxx.yaml
+++ b/org.mixxx.Mixxx.yaml
@@ -299,7 +299,7 @@ modules:
         url: https://github.com/xsco/libdjinterop/archive/refs/tags/0.24.3.tar.gz
         sha256: df41fe39bed9d16d27a3649d237b68edd2cdb6fc71a82cae5cd746d4e4ef6578
 
-  # Mixxx 2.5.2
+  # Mixxx 2.5.3
   - name: mixxx
     buildsystem: cmake-ninja
     config-opts:
@@ -315,7 +315,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/mixxxdj/mixxx.git
-        tag: '2.5.2'
+        tag: '2.5.3'
       - type: file
         path: org.mixxx.Mixxx.metainfo.xml
       - type: script


### PR DESCRIPTION
This PR updates Mixxx to newly released version 2.5.3. Dependencies and submodules were updated recently, so it's just a simple version tag bump with release notes.

Happy DJ'ing!